### PR TITLE
Revamp profile README with full project catalog, recognition, and testimonials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,116 @@
-# Siddhant Khare
+# Hi, I'm Siddhant 👋
 
-**Software Engineer at [Ona](https://ona.com/) (formerly Gitpod)** | **[OpenFGA](https://openfga.dev) Core Maintainer** | **KubeCon Speaker** | [**siddhantkhare.com**](https://siddhantkhare.com/)
+📍 **India** | 🛠️ **Engineer @ [Ona](https://ona.com/) (formerly Gitpod)** | 🔐 **[OpenFGA](https://openfga.dev) Core Maintainer** | 🎤 **KubeCon Speaker**
 
-> Building reliable infrastructure for AI agents - context efficiency, least-privilege security, production-grade tooling.
+![Go](https://img.shields.io/badge/-Go-00ADD8?style=flat-square&logo=go&logoColor=white)
+![TypeScript](https://img.shields.io/badge/-TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white)
+![Python](https://img.shields.io/badge/-Python-3776AB?style=flat-square&logo=python&logoColor=white)
+![Rust](https://img.shields.io/badge/-Rust-000000?style=flat-square&logo=rust&logoColor=white)
+![Kubernetes](https://img.shields.io/badge/-Kubernetes-326CE5?style=flat-square&logo=kubernetes&logoColor=white)
+![AWS](https://img.shields.io/badge/-AWS-232F3E?style=flat-square&logo=amazonwebservices&logoColor=white)
+![GCP](https://img.shields.io/badge/-GCP-4285F4?style=flat-square&logo=googlecloud&logoColor=white)
+![Docker](https://img.shields.io/badge/-Docker-2496ED?style=flat-square&logo=docker&logoColor=white)
 
-## 🎯 **Current Focus**
+> Building infrastructure for AI agents — context efficiency, least-privilege security, production-grade tooling.
 
-- **Engineering @ Ona (formerly Gitpod)**
-- **OpenFGA Core Maintainer**: First independent maintainer of CNCF Incubating authorization project
-- **Agent Infrastructure**: Building [Distill](https://distill.siddhantkhare.com) (context efficiency), Agent Authorization & Agent Audit Trails.
+## Current Projects
 
-## 📫 **Let's Connect**
+### Agent Infrastructure & Security
+- 🔐 **[agentic-authz](https://github.com/Siddhant-K-code/agentic-authz)** — OpenFGA + MCP authorization gateway for AI agents. Fine-grained access control at team, project, and tool levels.
+- 🧬 **[Distill](https://github.com/Siddhant-K-code/distill)** — Deterministic context deduplication for LLMs. Clean context in ~12ms, zero LLM calls.
+- 🔬 **[LLMTraceFX](https://github.com/Siddhant-K-code/LLMTraceFX)** — GPU-level LLM inference profiler with kernel timing and AI-powered bottleneck detection.
+- 🤖 **[Agentflow](https://github.com/Siddhant-K-code/agentflow)** — Kubernetes for AI agents — single platform for orchestration with capability-based security.
+- 🧪 **[ContextLab](https://github.com/Siddhant-K-code/contextlab)** — Open-source LLM context engineering toolkit: analyze, compress, visualize.
+- 💾 **[TokenVM](https://github.com/Siddhant-K-code/tokenvm)** — High-performance runtime treating LLM KV cache as virtual memory with page-based eviction.
 
-- **LinkedIn**: [siddhantkhare24](https://linkedin.com/in/siddhantkhare24)
-- **Twitter**: [@siddhantkhare](https://twitter.com/siddhantkhare)
-- **Email**: [siddhantkhare2694@gmail.com](mailto:siddhantkhare2694@gmail.com)
-- **MentorCruise**: [Book a mentoring session](https://mentorcruise.com/mentor/siddhantkhare/)
-- **GitHub Sponsors**: [Support my open source work](https://github.com/sponsors/Siddhant-K-code)
-- **YouTube**: [@siddhantkhare1659](https://youtube.com/@siddhantkhare1659)
+### Security & DevSecOps
+- 🛡️ **[Sentinel AI](https://github.com/Siddhant-K-code/sentinel-ai)** — Hermetic CLI for security scanning and dead-code detection with LLM-powered triage.
+- 🔒 **[actionsec](https://github.com/Siddhant-K-code/actionsec)** — Fast, local-first CLI for GitHub Actions security analysis.
+- 🔗 **[A2AS Implementation](https://github.com/Siddhant-K-code/a2as)** — Proof-of-concept of Agent-to-Agent Security framework.
 
----
+### Developer Tools & MCP Servers
+- 🏗️ **[Cloud Architect AI](https://github.com/Siddhant-K-code/cloud-architect-ai)** — AI-powered cloud infrastructure design with architecture diagrams and Terraform code.
+- 📝 **[Apple Notes MCP Server](https://github.com/Siddhant-K-code/apple-notes-mcp)** — Interact with Apple Notes via natural language.
+- 📸 **[Smart Photo Journal MCP Server](https://github.com/Siddhant-K-code/smart-photo-journal-mcp)** — Search and analyze your photo library with AI.
+- 🐳 **[Devcontainer MCP Server](https://github.com/Siddhant-K-code/devcontainer-mcp)** — Manage DevContainers using AI prompts.
+- 🧹 **[Gitpod Environment Cleanup](https://github.com/Siddhant-K-code/cleanup-gitpod-environments)** — GitHub Action to find & delete stale Gitpod environments.
 
-### Recent Technical blogs
+### Applications
+- 🎵 **[Song Vector Explorer](https://github.com/Siddhant-K-code/song-vector-explorer)** — Explore song lyrics as interactive 3D vector spaces.
+- 🗺️ **[SageMap](https://github.com/Siddhant-K-code/sagemap)** — Interactive tool to map and evolve personal beliefs.
+- 🏥 **[Radiology Copilot](https://github.com/Siddhant-K-code/radiology-copilot)** — Gemini-powered multimodal radiology assistant.
+
+### Maintainer Roles
+- 🔑 **[OpenFGA](https://github.com/openfga)** — Core Maintainer of Google Zanzibar-style fine-grained authorization system (CNCF Incubating). First independent maintainer.
+- 🔍 **[GitHub1s](https://github.com/conwnet/github1s)** — Maintainer of one-second code reading for GitHub repositories.
+
+### Legacy / Earlier Work
+- 🌍 **[Coronavirus Probability Checker](https://github.com/Siddhant-K-code/Coronavirus-Probability-Checker)** — COVID-19 probability checker based on symptom data.
+- 🩻 **[COVID-19 Rapid Tester](https://github.com/Siddhant-K-code/COVID-19-RAPID-TESTER)** — COVID-19 detector using chest X-ray analysis.
+- 🚀 **[404 Error Page — Astronaut](https://github.com/Siddhant-K-code/404-Error-Page---Astronaut)** — Animated 404 error page.
+
+## What I'm Doing
+
+- **Engineering @ [Ona](https://ona.com/)** — Building infrastructure for AI agents (formerly Gitpod).
+- **Open Source** — Maintaining OpenFGA, GitHub1s, and shipping agent infrastructure tools.
+- **Writing** — 40+ technical articles on AI infrastructure, security, and context engineering on [Dev.to](https://dev.to/siddhantkcode) and [Medium](https://medium.com/@siddhantkhare).
+- **Speaking** — KubeCon India 2025: *Beyond Productivity: Scaling Cloud Dev Environments for Faster Feedback & Sustainable Engineering*. Available for conferences on AI agent security and authorization.
+- **Mentoring** — [Book a session on MentorCruise](https://mentorcruise.com/mentor/siddhantkhare/).
+
+## Latest Blog Posts
 
 <!--START_SECTION:feed-->
 * [Ona (formerly Gitpod) is re-launching its Open Source program](https://dev.to/siddhantkcode/ona-formerly-gitpod-is-re-launching-its-open-source-program-5d3c)
-* [Containers aren’t a sandbox for AI agents](https://dev.to/siddhantkcode/containers-arent-a-sandbox-for-ai-agents-215o)
+* [Containers aren't a sandbox for AI agents](https://dev.to/siddhantkcode/containers-arent-a-sandbox-for-ai-agents-215o)
 * [The Engineering guide to Context window efficiency](https://dev.to/siddhantkcode/the-engineering-guide-to-context-window-efficiency-202b)
 * [Beyond finding: Remediating CVE-2025-55182 across hundreds of repositories with Ona Automations](https://dev.to/siddhantkcode/beyond-finding-remediating-cve-2025-55182-across-hundreds-of-repositories-with-ona-automations-1p3n)
 * [Securing Agentic AI: authorization patterns for autonomous systems](https://dev.to/siddhantkcode/securing-agentic-ai-authorization-patterns-for-autonomous-systems-3ajo)
 * [Context Engineering: The critical Infrastructure challenge in production LLM systems](https://dev.to/siddhantkcode/context-engineering-the-critical-infrastructure-challenge-in-production-llm-systems-4id0)
 * [AWS S3 Vectors at scale: Real performance numbers at 10 million Vectors](https://dev.to/siddhantkcode/aws-s3-vectors-at-scale-real-performance-numbers-at-10-million-vectors-2lno)
 * [Why agent orchestration is harder than kubernetes - Lessons while building Agentflow](https://dev.to/siddhantkcode/why-agent-orchestration-is-harder-than-kubernetes-lessons-while-building-agentflow-4jm3)
-* [Serverless economics: why Cloud Run crushes App Runner (until it doesn’t)](https://dev.to/siddhantkcode/serverless-economics-why-cloud-run-crushes-app-runner-until-it-doesnt-5fh3)
+* [Serverless economics: why Cloud Run crushes App Runner (until it doesn't)](https://dev.to/siddhantkcode/serverless-economics-why-cloud-run-crushes-app-runner-until-it-doesnt-5fh3)
 * [How to make AI code edits more accurate](https://dev.to/siddhantkcode/how-to-make-ai-code-edits-more-accurate-bbe)
 <!--END_SECTION:feed-->
 
+## Connect
 
+[![Twitter](https://img.shields.io/badge/-@Siddhant__K__code-1DA1F2?style=flat-square&logo=x&logoColor=white)](https://twitter.com/Siddhant_K_code)
+[![LinkedIn](https://img.shields.io/badge/-siddhantkhare24-0A66C2?style=flat-square&logo=linkedin&logoColor=white)](https://linkedin.com/in/siddhantkhare24)
+[![YouTube](https://img.shields.io/badge/-@siddhantkhare1659-FF0000?style=flat-square&logo=youtube&logoColor=white)](https://youtube.com/@siddhantkhare1659)
+[![Dev.to](https://img.shields.io/badge/-siddhantkcode-0A0A0A?style=flat-square&logo=devdotto&logoColor=white)](https://dev.to/siddhantkcode)
+[![Website](https://img.shields.io/badge/-siddhantkhare.com-000000?style=flat-square&logo=safari&logoColor=white)](https://siddhantkhare.com/)
+[![GitHub Sponsors](https://img.shields.io/badge/-Sponsor-EA4AAA?style=flat-square&logo=githubsponsors&logoColor=white)](https://github.com/sponsors/Siddhant-K-code)
+
+---
+
+### Recognition
+
+- **[OpenFGA](https://openfga.dev) Core Maintainer** — First independent maintainer of a CNCF Incubating authorization project
+- **KubeCon India 2025 Speaker** — *Beyond Productivity: Scaling Cloud Dev Environments*
+- **Former GitHub Intern** — Contributed to GitHub's ecosystem
+- **Maintainer** — [OpenFGA](https://github.com/openfga), [GitHub1s](https://github.com/conwnet/github1s), [Greenstand](https://github.com/Greenstand), [Indian Open Source Foundation](https://github.com/IndianOpenSourceFoundation)
+- **40+ technical articles** — Published on [Dev.to](https://dev.to/siddhantkcode) and [Medium](https://medium.com/@siddhantkhare), multiple posts with 100+ reactions
+
+### Videos
+
+- **[Beyond Productivity: Scaling Cloud Dev Environments](https://www.youtube.com/@siddhantkhare1659)** — KubeCon India 2025
+- **[AI Agents Are a Security Nightmare (Here's the Fix)](https://www.youtube.com/@siddhantkhare1659)** — Agent authorization deep dive
+- **[Building a Medical AI Agent with Gemini 3 Pro](https://www.youtube.com/@siddhantkhare1659)** — End-to-end agent build
+
+### What People Say
+
+> *"Siddhant is result-oriented like crazy, passionate like a co-founder, a humble team player."*
+> — **Michael Aring**, Head of EMEA at Ona (formerly Gitpod)
+
+> *"No one works faster or harder than Siddhant. He is one of the most thoughtful, passionate, and growth-minded people I've ever worked with."*
+> — **Talia Moyal**, PMM @ Lovable
+
+> *"He is fast becoming a force to reckon with."*
+> — **Laurie Malau**, Fractional Chief of Staff
+
+### Research Focus
+
+Building at the intersection of LLM efficiency and agent security:
+1. **Context Efficiency & Reliability** — Deterministic algorithms for context deduplication and optimization ([Distill](https://github.com/Siddhant-K-code/distill), [ContextLab](https://github.com/Siddhant-K-code/contextlab), [TokenVM](https://github.com/Siddhant-K-code/tokenvm))
+2. **Agent Authorization & Audit Trails** — Google Zanzibar-style authorization for agent-tool interactions ([agentic-authz](https://github.com/Siddhant-K-code/agentic-authz), [OpenFGA](https://github.com/openfga))
+3. **Adversarial Robustness & Observability** — Detecting and mitigating attacks on agent tool-use pipelines ([Sentinel AI](https://github.com/Siddhant-K-code/sentinel-ai), [LLMTraceFX](https://github.com/Siddhant-K-code/LLMTraceFX))

--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@
 - ⚡ **[Scalable LS](https://github.com/Siddhant-K-code/scalable-ls)** - List directories with millions of files (Rust).
 - 🗄️ **[S3 Backup Tool](https://github.com/Siddhant-K-code/poc-gocron)** - Scheduled backups with cron syntax (Go).
 - 🐙 **[GitHub Actions Self-Hosted Runner](https://github.com/Siddhant-K-code/gitpod-github-actions-self-hosted-runner)** - Debugging GitHub Actions using Gitpod.
+- 📊 **[GitHub Contribution Tracker](https://github.com/Siddhant-K-code/github-contribution-tracker)** - CLI tool to fetch and format all your GitHub contributions to any org.
+- 🖼️ **[Image Credential Masker](https://github.com/Siddhant-K-code/image-credential-masker)** - Identifying & obscuring personal/sensitive information in images.
+- 🎨 **[Satori Example](https://github.com/Siddhant-K-code/satori-example)** - Generate images from HTML/CSS using Satori.
+- 🔑 **[Get GitHub Actions SHA](https://github.com/Siddhant-K-code/get-gha-sha)** - Fetch commit SHA for GitHub Actions tags.
+- 💳 **[Stripe Overdue Invoice Cleaner](https://github.com/Siddhant-K-code/stripe-overdue-invoice-cleaner)** - Automatically void overdue Stripe invoices.
+- 🌱 **[Greenhouse Data Exporter](https://github.com/Siddhant-K-code/greenhouse-data-exporter)** - Export candidate data from Greenhouse.io to CSV.
+- 📋 **[Sheets to CSV Converter](https://github.com/Siddhant-K-code/sheets-to-csv-converter)** - xlsx to CSV CLI converter (Go).
+- 📜 **[Patent Summarizer](https://github.com/Siddhant-K-code/patent-summarizer)** - Patent summarization using OpenAI.
+- 🔧 **[Contextify](https://github.com/Siddhant-K-code/Contextify)** - Lightweight script for LLM context injection from project files.
+- 📈 **[Gitpod Runner Analyzer](https://github.com/Siddhant-K-code/gitpod-runner-analyzer)** - Gitpod Flex runner resource analyzer.
+- 🛒 **[Amazon CLI](https://github.com/Siddhant-K-code/Amazon_CLI)** - Amazon product search from the terminal using scraping.
+- ⚙️ **[Slice vs Iterator Benchmarking](https://github.com/Siddhant-K-code/slice-vs-iterator-benchmarking)** - Slices vs Iterators benchmarking in Go v1.23.
 
 ### Applications
 - 🎵 **[Song Vector Explorer](https://github.com/Siddhant-K-code/song-vector-explorer)** - Explore song lyrics as interactive 3D vector spaces.
@@ -46,6 +58,10 @@
 - 💊 **[MediSearchAI](https://github.com/Siddhant-K-code/MediSearchAI)** - A smarter way to search for medicines.
 - 📄 **[MedBrief](https://github.com/Siddhant-K-code/MedBrief)** - Automated PubMed research paper summarization into narrated videos.
 - 🔗 **[LangChain x OpenAI: Bring Your Own Data](https://github.com/Siddhant-K-code/OpenAI-bring-your-own-data)** - Train with custom markdown data using LangChain.
+- 🤖 **[GPT-CLI](https://github.com/Siddhant-K-code/GPT-CLI)** - GPT in your terminal.
+- 📊 **[S3 Vectors Benchmark](https://github.com/Siddhant-K-code/s3-vectors-benchmark)** - AWS S3 Vectors performance benchmarking at scale.
+- 📈 **[Visualize Stock Market](https://github.com/Siddhant-K-code/Visualize-Stock-Market)** - Stock market data visualization.
+- 🔬 **[Logistic Regression - Breast Cancer](https://github.com/Siddhant-K-code/Logistic_Regression_with_Breast_Cancer_Data)** - ML classification on breast cancer data.
 
 ### Maintainer Roles
 - 🔑 **[OpenFGA](https://github.com/openfga)** - Core Maintainer of Google Zanzibar-style fine-grained authorization system (CNCF Incubating). First independent maintainer.
@@ -56,11 +72,18 @@
 - 🐬 **[MySQL Replica Server](https://github.com/Siddhant-K-code/mysql-replica-server)** - MySQL master-slave replication setup in Docker.
 - 💬 **[React Chat Application](https://github.com/Siddhant-K-code/React-Chat-Application)** - Real-time online chat application with rooms.
 - 📊 **[GitHub User Analytics](https://github.com/Siddhant-K-code/Github-user-analytics)** - GitHub user analysis with charts using React, Auth0, and FusionCharts.
+- 📦 **[JSON to Table](https://github.com/Siddhant-K-code/JSON-to-Table)** - JSON data to HTML table converter.
+- 🔄 **[CRUD TypeScript](https://github.com/Siddhant-K-code/CRUD-TypeScript)** - CRUD REST API using TypeScript, PostgreSQL, and TypeORM.
+- 💱 **[Currency Converter](https://github.com/Siddhant-K-code/currency-convert-example)** - Currency converter CLI with MetaCall.
+- 🔀 **[Sorting Algorithms Visualizer](https://github.com/Siddhant-K-code/Sorting-Algorithms-Visualizer)** - Visual sorting algorithm comparisons.
+- 🔌 **[Logic Gates Simulator](https://github.com/Siddhant-K-code/Logic-Gates-Simulator)** - Interactive logic gates simulator.
+- 🧭 **[Pathfinding Algorithms Visualizer](https://github.com/Siddhant-K-code/Pathfinding-Algorithms-Visualizer)** - Pathfinding algorithm visualization.
 - 🎨 **[Mandala Maker](https://github.com/Siddhant-K-code/Mandala-Maker)** - Online mandala drawing tool.
 - 🧩 **[JavaScript Sudoku Puzzle](https://github.com/Siddhant-K-code/JavaScript-Sudoku-Puzzle-Generator)** - Sudoku puzzle generator & solver.
 - ♟️ **[Chess](https://github.com/Siddhant-K-code/Chess)** - Chess in HTML/CSS/JS.
 - 🌍 **[Coronavirus Probability Checker](https://github.com/Siddhant-K-code/Coronavirus-Probability-Checker)** - COVID-19 probability checker based on symptom data.
 - 🩻 **[COVID-19 Rapid Tester](https://github.com/Siddhant-K-code/COVID-19-RAPID-TESTER)** - COVID-19 detector using chest X-ray analysis.
+- 🔔 **[COVID-19 Outbreak Notification](https://github.com/Siddhant-K-code/Coronavirus-Outbreak-Notification-Alert)** - Live notification alerts from official sources.
 - 🚀 **[404 Error Page - Astronaut](https://github.com/Siddhant-K-code/404-Error-Page---Astronaut)** - Animated 404 error page.
 
 ## What I'm Doing

--- a/README.md
+++ b/README.md
@@ -7,36 +7,58 @@
 
 ## Current Projects
 
-### Agent Infrastructure & Security
-- 🔐 **[agentic-authz](https://github.com/Siddhant-K-code/agentic-authz)** - OpenFGA + MCP authorization gateway for AI agents. Fine-grained access control at team, project, and tool levels.
+### Agent Infrastructure & Context Engineering
 - 🧬 **[Distill](https://github.com/Siddhant-K-code/distill)** - Deterministic context deduplication for LLMs. Clean context in ~12ms, zero LLM calls.
-- 🔬 **[LLMTraceFX](https://github.com/Siddhant-K-code/LLMTraceFX)** - GPU-level LLM inference profiler with kernel timing and AI-powered bottleneck detection.
-- 🤖 **[Agentflow](https://github.com/Siddhant-K-code/agentflow)** - Kubernetes for AI agents - single platform for orchestration with capability-based security.
-- 🧪 **[ContextLab](https://github.com/Siddhant-K-code/contextlab)** - Open-source LLM context engineering toolkit: analyze, compress, visualize.
+- 🧪 **[ContextLab](https://github.com/Siddhant-K-code/ContextLab)** - Open-source LLM context engineering toolkit: analyze, compress, visualize.
 - 💾 **[TokenVM](https://github.com/Siddhant-K-code/tokenvm)** - High-performance runtime treating LLM KV cache as virtual memory with page-based eviction.
+- 📊 **[KV-Cache Profiler](https://github.com/Siddhant-K-code/kv-cache-profiler)** - Profile LLM GPU memory needs before deployment, not after.
+- 🔬 **[LLMTraceFX](https://github.com/Siddhant-K-code/LLMTraceFX)** - GPU-level LLM inference profiler with kernel timing and AI-powered bottleneck detection.
+- 🤖 **[Agentflow](https://github.com/Siddhant-K-code/agentflow)** - Kubernetes for AI agents - orchestration runtime, prompt ops, security layer, observability, and cost-aware scheduling.
+- 🌐 **[AI Agent Orchestrator](https://github.com/Siddhant-K-code/ai-agent-orchestrator)** - Multi-agent AI system on Cloudflare Workers + Containers.
+- 🔢 **[LLM Parallelism Explorer](https://github.com/Siddhant-K-code/llm-parallelism-explorer-poc)** - Research tool for optimizing parallelism strategies in LLMs (MoE focus).
+- 💰 **[CloudArb](https://github.com/Siddhant-K-code/CloudArb)** - GPU arbitrage platform for AI compute optimization.
 
-### Security & DevSecOps
+### Agent Security & Authorization
+- 🔐 **[agentic-authz](https://github.com/Siddhant-K-code/agentic-authz)** - OpenFGA + MCP authorization gateway for AI agents. Fine-grained access control at team, project, and tool levels.
+- 🔏 **[Agentic Authorization](https://github.com/Siddhant-K-code/agentic-authorization)** - Authorization patterns for autonomous AI agent systems using ReBAC with OpenFGA.
+- 🔗 **[A2AS Implementation](https://github.com/Siddhant-K-code/a2as-implementation-poc)** - Proof-of-concept of Agent-to-Agent Security framework.
 - 🛡️ **[Sentinel AI](https://github.com/Siddhant-K-code/sentinel-ai)** - Hermetic CLI for security scanning and dead-code detection with LLM-powered triage.
 - 🔒 **[actionsec](https://github.com/Siddhant-K-code/actionsec)** - Fast, local-first CLI for GitHub Actions security analysis.
-- 🔗 **[A2AS Implementation](https://github.com/Siddhant-K-code/a2as)** - Proof-of-concept of Agent-to-Agent Security framework.
 
 ### Developer Tools & MCP Servers
 - 🏗️ **[Cloud Architect AI](https://github.com/Siddhant-K-code/cloud-architect-ai)** - AI-powered cloud infrastructure design with architecture diagrams and Terraform code.
-- 📝 **[Apple Notes MCP Server](https://github.com/Siddhant-K-code/apple-notes-mcp)** - Interact with Apple Notes via natural language.
-- 📸 **[Smart Photo Journal MCP Server](https://github.com/Siddhant-K-code/smart-photo-journal-mcp)** - Search and analyze your photo library with AI.
-- 🐳 **[Devcontainer MCP Server](https://github.com/Siddhant-K-code/devcontainer-mcp)** - Manage DevContainers using AI prompts.
+- 📝 **[Apple Notes MCP Server](https://github.com/Siddhant-K-code/mcp-apple-notes)** - Interact with Apple Notes via natural language.
+- 📸 **[Memory Journal MCP Server](https://github.com/Siddhant-K-code/memory-journal-mcp-server)** - Search and analyze your photo library with AI.
+- 🐳 **[Devcontainer MCP Server](https://github.com/Siddhant-K-code/mcp-devcontainer)** - Manage DevContainers using AI prompts.
+- 📰 **[Dev.to MCP Server](https://github.com/Siddhant-K-code/mcp-devto-server)** - MCP server for Dev.to.
 - 🧹 **[Gitpod Environment Cleanup](https://github.com/Siddhant-K-code/cleanup-gitpod-environments)** - GitHub Action to find & delete stale Gitpod environments.
+- 🔍 **[GitHub Venture Scout](https://github.com/Siddhant-K-code/github-venture-scout)** - AI-powered GitHub profile analyzer for identifying investment-worthy projects.
+- 🇮🇳 **[Sponsorable GitHub Users in India](https://github.com/Siddhant-K-code/sponsorable-github-users-in-india)** - Top 1,000 sponsorable GitHub developers in India, auto-updated daily.
+- ⚡ **[Scalable LS](https://github.com/Siddhant-K-code/scalable-ls)** - List directories with millions of files (Rust).
+- 🗄️ **[S3 Backup Tool](https://github.com/Siddhant-K-code/poc-gocron)** - Scheduled backups with cron syntax (Go).
+- 🐙 **[GitHub Actions Self-Hosted Runner](https://github.com/Siddhant-K-code/gitpod-github-actions-self-hosted-runner)** - Debugging GitHub Actions using Gitpod.
 
 ### Applications
 - 🎵 **[Song Vector Explorer](https://github.com/Siddhant-K-code/song-vector-explorer)** - Explore song lyrics as interactive 3D vector spaces.
-- 🗺️ **[SageMap](https://github.com/Siddhant-K-code/sagemap)** - Interactive tool to map and evolve personal beliefs.
+- 🗺️ **[SageMap](https://github.com/Siddhant-K-code/SageMap)** - Interactive tool to map and evolve personal beliefs.
 - 🏥 **[Radiology Copilot](https://github.com/Siddhant-K-code/radiology-copilot)** - Gemini-powered multimodal radiology assistant.
+- 🏛️ **[ArchiFusion](https://github.com/Siddhant-K-code/ArchiFusion)** - Transforms architectural ideas into 3D building models.
+- 💊 **[MediSearchAI](https://github.com/Siddhant-K-code/MediSearchAI)** - A smarter way to search for medicines.
+- 📄 **[MedBrief](https://github.com/Siddhant-K-code/MedBrief)** - Automated PubMed research paper summarization into narrated videos.
+- 🔗 **[LangChain x OpenAI: Bring Your Own Data](https://github.com/Siddhant-K-code/OpenAI-bring-your-own-data)** - Train with custom markdown data using LangChain.
 
 ### Maintainer Roles
 - 🔑 **[OpenFGA](https://github.com/openfga)** - Core Maintainer of Google Zanzibar-style fine-grained authorization system (CNCF Incubating). First independent maintainer.
 - 🔍 **[GitHub1s](https://github.com/conwnet/github1s)** - Maintainer of one-second code reading for GitHub repositories.
 
 ### Legacy / Earlier Work
+- 📍 **[Geo-Location Attendance System](https://github.com/Siddhant-K-code/Geo-Location-Attendance-System)** - Geo-based attendance system for college students (Dart/Flutter).
+- 🐬 **[MySQL Replica Server](https://github.com/Siddhant-K-code/mysql-replica-server)** - MySQL master-slave replication setup in Docker.
+- 💬 **[React Chat Application](https://github.com/Siddhant-K-code/React-Chat-Application)** - Real-time online chat application with rooms.
+- 📊 **[GitHub User Analytics](https://github.com/Siddhant-K-code/Github-user-analytics)** - GitHub user analysis with charts using React, Auth0, and FusionCharts.
+- 🎨 **[Mandala Maker](https://github.com/Siddhant-K-code/Mandala-Maker)** - Online mandala drawing tool.
+- 🧩 **[JavaScript Sudoku Puzzle](https://github.com/Siddhant-K-code/JavaScript-Sudoku-Puzzle-Generator)** - Sudoku puzzle generator & solver.
+- ♟️ **[Chess](https://github.com/Siddhant-K-code/Chess)** - Chess in HTML/CSS/JS.
 - 🌍 **[Coronavirus Probability Checker](https://github.com/Siddhant-K-code/Coronavirus-Probability-Checker)** - COVID-19 probability checker based on symptom data.
 - 🩻 **[COVID-19 Rapid Tester](https://github.com/Siddhant-K-code/COVID-19-RAPID-TESTER)** - COVID-19 detector using chest X-ray analysis.
 - 🚀 **[404 Error Page - Astronaut](https://github.com/Siddhant-K-code/404-Error-Page---Astronaut)** - Animated 404 error page.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hi, I'm Siddhant Khare 👋
 
-📍 **India** | 🛠️ **Engineer @ [Ona](https://ona.com/) (formerly Gitpod)** | 🔐 **[OpenFGA](https://openfga.dev) Core Maintainer** | 🎤 **KubeCon Speaker**
+📍 **India** | 🛠️ **Engineer @ [Ona](https://ona.com/) (formerly Gitpod)** | 🔐 **[OpenFGA](https://openfga.dev) Core Maintainer** | 🎤 **KubeCon Speaker** | [**siddhantkhare.com**](https://siddhantkhare.com/)
 
 ![Go](https://img.shields.io/badge/-Go-00ADD8?style=flat-square&logo=go&logoColor=white)
 ![TypeScript](https://img.shields.io/badge/-TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white)

--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@
 - **[The Chosun Ilbo](https://www.chosun.com/english/industry-en/2026/02/12/YJMVMG56ORHVJDHMKDQM2QMFCE/)** (South Korea's largest newspaper) - *"AI Fatigue Grows Despite Productivity Gains"*
 - **[NDTV Profit](https://www.ndtvprofit.com/technology/ai-backfire-stress-induced-burnout-could-be-tanking-your-work-quality-study-finds-10981522)** - Video segment on AI burnout
 - **[Computing UK](https://www.computing.co.uk/feature/2026/when-artificial-intelligence-makes-you-tired)** - Quoted extensively on AI fatigue
-- **[Kelsey Hightower](https://www.linkedin.com/in/kelseyhightower/)** - *"It's very real, which is why I'm glad people like you are raising awareness"*
 - Syndicated across **Yahoo**, **AOL**, **Business Insider Nordic/Africa/Italy**, **NewsBreak**, **daily.dev**, **Lobsters**, and others
 - Discussed on **Precursor Ventures** podcast by Charles Hudson and Mia Farnham
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@
 - **[Business Insider](https://www.businessinsider.com/ai-fatigue-burnout-software-engineer-essay-siddhant-khare-2026-2)** - Featured essay + [video segment](https://www.businessinsider.com/engineers-are-getting-ai-fatigue-and-you-could-be-next-2026-2)
 - **[Futurism](https://futurism.com/artificial-intelligence/ai-burnout-machine)** - *"AI Is a Burnout Machine"*
 - **[Techmeme](http://www.techmeme.com/260208/p15)** - Front page feature
-- **[Hacker News](https://news.ycombinator.com/item?id=46934404)** - #1, 446+ points, 310+ comments
+- **[Hacker News](https://news.ycombinator.com/item?id=46934404)** - #1, 450+ points, 310+ comments
 - **[The Chosun Ilbo](https://www.chosun.com/english/industry-en/2026/02/12/YJMVMG56ORHVJDHMKDQM2QMFCE/)** (South Korea's largest newspaper) - *"AI Fatigue Grows Despite Productivity Gains"*
 - **[NDTV Profit](https://www.ndtvprofit.com/technology/ai-backfire-stress-induced-burnout-could-be-tanking-your-work-quality-study-finds-10981522)** - Video segment on AI burnout
 - **[Computing UK](https://www.computing.co.uk/feature/2026/when-artificial-intelligence-makes-you-tired)** - Quoted extensively on AI fatigue

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@
 - **[NDTV Profit](https://www.ndtvprofit.com/technology/ai-backfire-stress-induced-burnout-could-be-tanking-your-work-quality-study-finds-10981522)** - Video segment on AI burnout
 - **[Computing UK](https://www.computing.co.uk/feature/2026/when-artificial-intelligence-makes-you-tired)** - Quoted extensively on AI fatigue
 - Syndicated across **Yahoo**, **AOL**, **Business Insider Nordic/Africa/Italy**, **NewsBreak**, **daily.dev**, **Lobsters**, and others
-- Discussed on **Precursor Ventures** podcast by Charles Hudson and Mia Farnham
+- Discussed on **[Precursor Ventures](https://www.linkedin.com/posts/mia-farnham-a3295b68_julia-maltby-wrote-a-great-piece-on-tips-activity-7427803709406920704-uRpi)** podcast by Charles Hudson and Mia Farnham
 
 ### Videos
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,7 @@
 # Hi, I'm Siddhant Khare 👋
 
-📍 **India** | 🛠️ **Engineer @ [Ona](https://ona.com/) (formerly Gitpod)** | 🔐 **[OpenFGA](https://openfga.dev) Core Maintainer** | 🎤 **KubeCon Speaker** | [**siddhantkhare.com**](https://siddhantkhare.com/)
+📍 **India** | 🛠️ **Engineer @ [Ona](https://ona.com/) (formerly Gitpod)** | 🔐 **[OpenFGA](https://openfga.dev) Core Maintainer** | 🎤 **International Speaker** | [**siddhantkhare.com**](https://siddhantkhare.com/)
 
-![Go](https://img.shields.io/badge/-Go-00ADD8?style=flat-square&logo=go&logoColor=white)
-![TypeScript](https://img.shields.io/badge/-TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white)
-![Python](https://img.shields.io/badge/-Python-3776AB?style=flat-square&logo=python&logoColor=white)
-![Rust](https://img.shields.io/badge/-Rust-000000?style=flat-square&logo=rust&logoColor=white)
-![Kubernetes](https://img.shields.io/badge/-Kubernetes-326CE5?style=flat-square&logo=kubernetes&logoColor=white)
-![AWS](https://img.shields.io/badge/-AWS-232F3E?style=flat-square&logo=amazonwebservices&logoColor=white)
-![GCP](https://img.shields.io/badge/-GCP-4285F4?style=flat-square&logo=googlecloud&logoColor=white)
-![Docker](https://img.shields.io/badge/-Docker-2496ED?style=flat-square&logo=docker&logoColor=white)
 
 > Building infrastructure for AI agents — context efficiency, least-privilege security, production-grade tooling.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 📍 **India** | 🛠️ **Engineer @ [Ona](https://ona.com/) (formerly Gitpod)** | 🔐 **[OpenFGA](https://openfga.dev) Core Maintainer** | 🎤 **International Speaker** | [**siddhantkhare.com**](https://siddhantkhare.com/)
 
-
 > Building infrastructure for AI agents - context efficiency, least-privilege security, production-grade tooling.
 
 ## Current Projects
@@ -31,24 +30,18 @@
 - 📸 **[Memory Journal MCP Server](https://github.com/Siddhant-K-code/memory-journal-mcp-server)** - Search and analyze your photo library with AI.
 - 🐳 **[Devcontainer MCP Server](https://github.com/Siddhant-K-code/mcp-devcontainer)** - Manage DevContainers using AI prompts.
 - 📰 **[Dev.to MCP Server](https://github.com/Siddhant-K-code/mcp-devto-server)** - MCP server for Dev.to.
+- 🔧 **[Contextify](https://github.com/Siddhant-K-code/Contextify)** - Lightweight script for LLM context injection from project files.
 - 🧹 **[Gitpod Environment Cleanup](https://github.com/Siddhant-K-code/cleanup-gitpod-environments)** - GitHub Action to find & delete stale Gitpod environments.
-- 🔍 **[GitHub Venture Scout](https://github.com/Siddhant-K-code/github-venture-scout)** - AI-powered GitHub profile analyzer for identifying investment-worthy projects.
+- 📈 **[Gitpod Runner Analyzer](https://github.com/Siddhant-K-code/gitpod-runner-analyzer)** - Gitpod Flex runner resource analyzer.
+- 🐙 **[GitHub Actions Self-Hosted Runner](https://github.com/Siddhant-K-code/gitpod-github-actions-self-hosted-runner)** - Debugging GitHub Actions using Gitpod.
+- 🏷️ **[Get GitHub Actions SHA](https://github.com/Siddhant-K-code/get-gha-sha)** - Fetch commit SHA for GitHub Actions tags.
+- 🕵️ **[GitHub Venture Scout](https://github.com/Siddhant-K-code/github-venture-scout)** - AI-powered GitHub profile analyzer for identifying investment-worthy projects.
 - 🇮🇳 **[Sponsorable GitHub Users in India](https://github.com/Siddhant-K-code/sponsorable-github-users-in-india)** - Top 1,000 sponsorable GitHub developers in India, auto-updated daily.
 - ⚡ **[Scalable LS](https://github.com/Siddhant-K-code/scalable-ls)** - List directories with millions of files (Rust).
-- 🗄️ **[S3 Backup Tool](https://github.com/Siddhant-K-code/poc-gocron)** - Scheduled backups with cron syntax (Go).
-- 🐙 **[GitHub Actions Self-Hosted Runner](https://github.com/Siddhant-K-code/gitpod-github-actions-self-hosted-runner)** - Debugging GitHub Actions using Gitpod.
-- 📊 **[GitHub Contribution Tracker](https://github.com/Siddhant-K-code/github-contribution-tracker)** - CLI tool to fetch and format all your GitHub contributions to any org.
 - 🖼️ **[Image Credential Masker](https://github.com/Siddhant-K-code/image-credential-masker)** - Identifying & obscuring personal/sensitive information in images.
-- 🎨 **[Satori Example](https://github.com/Siddhant-K-code/satori-example)** - Generate images from HTML/CSS using Satori.
-- 🔑 **[Get GitHub Actions SHA](https://github.com/Siddhant-K-code/get-gha-sha)** - Fetch commit SHA for GitHub Actions tags.
 - 💳 **[Stripe Overdue Invoice Cleaner](https://github.com/Siddhant-K-code/stripe-overdue-invoice-cleaner)** - Automatically void overdue Stripe invoices.
 - 🌱 **[Greenhouse Data Exporter](https://github.com/Siddhant-K-code/greenhouse-data-exporter)** - Export candidate data from Greenhouse.io to CSV.
-- 📋 **[Sheets to CSV Converter](https://github.com/Siddhant-K-code/sheets-to-csv-converter)** - xlsx to CSV CLI converter (Go).
 - 📜 **[Patent Summarizer](https://github.com/Siddhant-K-code/patent-summarizer)** - Patent summarization using OpenAI.
-- 🔧 **[Contextify](https://github.com/Siddhant-K-code/Contextify)** - Lightweight script for LLM context injection from project files.
-- 📈 **[Gitpod Runner Analyzer](https://github.com/Siddhant-K-code/gitpod-runner-analyzer)** - Gitpod Flex runner resource analyzer.
-- 🛒 **[Amazon CLI](https://github.com/Siddhant-K-code/Amazon_CLI)** - Amazon product search from the terminal using scraping.
-- ⚙️ **[Slice vs Iterator Benchmarking](https://github.com/Siddhant-K-code/slice-vs-iterator-benchmarking)** - Slices vs Iterators benchmarking in Go v1.23.
 
 ### Applications
 - 🎵 **[Song Vector Explorer](https://github.com/Siddhant-K-code/song-vector-explorer)** - Explore song lyrics as interactive 3D vector spaces.
@@ -57,11 +50,8 @@
 - 🏛️ **[ArchiFusion](https://github.com/Siddhant-K-code/ArchiFusion)** - Transforms architectural ideas into 3D building models.
 - 💊 **[MediSearchAI](https://github.com/Siddhant-K-code/MediSearchAI)** - A smarter way to search for medicines.
 - 📄 **[MedBrief](https://github.com/Siddhant-K-code/MedBrief)** - Automated PubMed research paper summarization into narrated videos.
-- 🔗 **[LangChain x OpenAI: Bring Your Own Data](https://github.com/Siddhant-K-code/OpenAI-bring-your-own-data)** - Train with custom markdown data using LangChain.
-- 🤖 **[GPT-CLI](https://github.com/Siddhant-K-code/GPT-CLI)** - GPT in your terminal.
-- 📊 **[S3 Vectors Benchmark](https://github.com/Siddhant-K-code/s3-vectors-benchmark)** - AWS S3 Vectors performance benchmarking at scale.
-- 📈 **[Visualize Stock Market](https://github.com/Siddhant-K-code/Visualize-Stock-Market)** - Stock market data visualization.
-- 🔬 **[Logistic Regression - Breast Cancer](https://github.com/Siddhant-K-code/Logistic_Regression_with_Breast_Cancer_Data)** - ML classification on breast cancer data.
+- 📚 **[LangChain x OpenAI: Bring Your Own Data](https://github.com/Siddhant-K-code/OpenAI-bring-your-own-data)** - Train with custom markdown data using LangChain.
+- 🖥️ **[GPT-CLI](https://github.com/Siddhant-K-code/GPT-CLI)** - GPT in your terminal.
 
 ### Maintainer Roles
 - 🔑 **[OpenFGA](https://github.com/openfga)** - Core Maintainer of Google Zanzibar-style fine-grained authorization system (CNCF Incubating). First independent maintainer.
@@ -71,10 +61,19 @@
 - 📍 **[Geo-Location Attendance System](https://github.com/Siddhant-K-code/Geo-Location-Attendance-System)** - Geo-based attendance system for college students (Dart/Flutter).
 - 🐬 **[MySQL Replica Server](https://github.com/Siddhant-K-code/mysql-replica-server)** - MySQL master-slave replication setup in Docker.
 - 💬 **[React Chat Application](https://github.com/Siddhant-K-code/React-Chat-Application)** - Real-time online chat application with rooms.
-- 📊 **[GitHub User Analytics](https://github.com/Siddhant-K-code/Github-user-analytics)** - GitHub user analysis with charts using React, Auth0, and FusionCharts.
+- 📉 **[GitHub User Analytics](https://github.com/Siddhant-K-code/Github-user-analytics)** - GitHub user analysis with charts using React, Auth0, and FusionCharts.
+- 💹 **[Visualize Stock Market](https://github.com/Siddhant-K-code/Visualize-Stock-Market)** - Stock market data visualization.
+- 🧫 **[Logistic Regression - Breast Cancer](https://github.com/Siddhant-K-code/Logistic_Regression_with_Breast_Cancer_Data)** - ML classification on breast cancer data.
+- 🛒 **[Amazon CLI](https://github.com/Siddhant-K-code/Amazon_CLI)** - Amazon product search from the terminal using scraping.
+- 📋 **[Sheets to CSV Converter](https://github.com/Siddhant-K-code/sheets-to-csv-converter)** - xlsx to CSV CLI converter (Go).
+- 🗄️ **[S3 Backup Tool](https://github.com/Siddhant-K-code/poc-gocron)** - Scheduled backups with cron syntax (Go).
+- ⚙️ **[Slice vs Iterator Benchmarking](https://github.com/Siddhant-K-code/slice-vs-iterator-benchmarking)** - Slices vs Iterators benchmarking in Go v1.23.
 - 📦 **[JSON to Table](https://github.com/Siddhant-K-code/JSON-to-Table)** - JSON data to HTML table converter.
 - 🔄 **[CRUD TypeScript](https://github.com/Siddhant-K-code/CRUD-TypeScript)** - CRUD REST API using TypeScript, PostgreSQL, and TypeORM.
 - 💱 **[Currency Converter](https://github.com/Siddhant-K-code/currency-convert-example)** - Currency converter CLI with MetaCall.
+- 🎯 **[S3 Vectors Benchmark](https://github.com/Siddhant-K-code/s3-vectors-benchmark)** - AWS S3 Vectors performance benchmarking at scale.
+- 🖌️ **[Satori Image Generator](https://github.com/Siddhant-K-code/satori-example)** - Generate images from HTML/CSS using Satori.
+- 📐 **[GitHub Contribution Tracker](https://github.com/Siddhant-K-code/github-contribution-tracker)** - CLI to fetch and format GitHub contributions to any org.
 - 🔀 **[Sorting Algorithms Visualizer](https://github.com/Siddhant-K-code/Sorting-Algorithms-Visualizer)** - Visual sorting algorithm comparisons.
 - 🔌 **[Logic Gates Simulator](https://github.com/Siddhant-K-code/Logic-Gates-Simulator)** - Interactive logic gates simulator.
 - 🧭 **[Pathfinding Algorithms Visualizer](https://github.com/Siddhant-K-code/Pathfinding-Algorithms-Visualizer)** - Pathfinding algorithm visualization.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 
 - **Engineering @ [Ona](https://ona.com/)** - Building infrastructure for AI agents (formerly Gitpod).
 - **Open Source** - Maintaining OpenFGA, GitHub1s, and shipping agent infrastructure tools.
-- **Writing** - 40+ technical articles on AI infrastructure, security, and context engineering on [Dev.to](https://dev.to/siddhantkcode) and [Medium](https://medium.com/@siddhantkhare).
+- **Writing** - 40+ technical articles on AI infrastructure, security, and context engineering on [siddhantkhare.com/writing](https://siddhantkhare.com/writing).
 - **Speaking** - KubeCon India 2025: *Beyond Productivity: Scaling Cloud Dev Environments for Faster Feedback & Sustainable Engineering*. Available for conferences on AI agent security and authorization.
 - **Mentoring** - [Book a session on MentorCruise](https://mentorcruise.com/mentor/siddhantkhare/).
 
@@ -82,7 +82,7 @@
 - **KubeCon India 2025 Speaker** - *Beyond Productivity: Scaling Cloud Dev Environments*
 - **Former GitHub Intern**
 - **Maintainer** - [OpenFGA](https://github.com/openfga), [GitHub1s](https://github.com/conwnet/github1s), [Greenstand](https://github.com/Greenstand), [Indian Open Source Foundation](https://github.com/IndianOpenSourceFoundation)
-- **40+ technical articles** - Published on [Dev.to](https://dev.to/siddhantkcode) and [Medium](https://medium.com/@siddhantkhare), multiple posts with 100+ reactions
+- **40+ technical articles** - Published on [siddhantkhare.com/writing](https://siddhantkhare.com/writing), multiple posts with 100+ reactions
 - **Interviewed by [New York Times](https://www.nytimes.com/)** (Cade Metz) and **[NPR Here & Now](https://www.wbur.org/hereandnow)** on AI fatigue
 - **[Business Insider](https://www.businessinsider.com/ai-fatigue-burnout-software-engineer-essay-siddhant-khare-2026-2)** - Featured essay + [video segment](https://www.businessinsider.com/engineers-are-getting-ai-fatigue-and-you-could-be-next-2026-2)
 - **[Futurism](https://futurism.com/artificial-intelligence/ai-burnout-machine)** - *"AI Is a Burnout Machine"*

--- a/README.md
+++ b/README.md
@@ -90,16 +90,15 @@
 - **[AI Agents Are a Security Nightmare (Here's the Fix)](https://www.youtube.com/@siddhantkhare1659)** — Agent authorization deep dive
 - **[Building a Medical AI Agent with Gemini 3 Pro](https://www.youtube.com/@siddhantkhare1659)** — End-to-end agent build
 
-### What People Say
+### Media Coverage
 
-> *"Siddhant is result-oriented like crazy, passionate like a co-founder, a humble team player."*
-> — **Michael Aring**, Head of EMEA at Ona (formerly Gitpod)
-
-> *"No one works faster or harder than Siddhant. He is one of the most thoughtful, passionate, and growth-minded people I've ever worked with."*
-> — **Talia Moyal**, PMM @ Lovable
-
-> *"He is fast becoming a force to reckon with."*
-> — **Laurie Malau**, Fractional Chief of Staff
+- **[Techmeme](http://www.techmeme.com/260208/p15)** — *"A software engineer explains 'AI fatigue', compounded by a FOMO treadmill of using AI labs' latest tools and 'thinking atrophy', alongside boosted productivity"*
+- **[Business Insider](https://www.businessinsider.com/ai-fatigue-burnout-software-engineer-essay-siddhant-khare-2026-2)** — *"'AI fatigue is real and nobody talks about it': A software engineer warns there's a mental cost to AI productivity gains"*
+- **[Hacker News](https://news.ycombinator.com/item?id=46934404)** — #1 on front page, 471+ points, 319+ comments
+- **[Computing UK](https://www.computing.co.uk/feature/2026/when-artificial-intelligence-makes-you-tired)** — *"AI fatigue: When artificial intelligence makes you tired"*
+- **[NewsBreak](https://www.newsbreak.com/morningoverview-358954986/4487947176601-ai-fatigue-is-real-engineer-warns-of-mental-toll-behind-ai-productivity-boom)** — *"'AI fatigue is real': engineer warns of mental toll behind AI productivity boom"*
+- **[Lobsters](https://lobste.rs/)** — Featured on front page
+- **[Kelsey Hightower](https://www.linkedin.com/in/kelseyhightower/)** (LinkedIn) — Shared and commented on the article
 
 ### Research Focus
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Hi, I'm Siddhant 👋
+# Hi, I'm Siddhant Khare 👋
 
 📍 **India** | 🛠️ **Engineer @ [Ona](https://ona.com/) (formerly Gitpod)** | 🔐 **[OpenFGA](https://openfga.dev) Core Maintainer** | 🎤 **KubeCon Speaker**
 
@@ -80,6 +80,7 @@
 [![Dev.to](https://img.shields.io/badge/-siddhantkcode-0A0A0A?style=flat-square&logo=devdotto&logoColor=white)](https://dev.to/siddhantkcode)
 [![Website](https://img.shields.io/badge/-siddhantkhare.com-000000?style=flat-square&logo=safari&logoColor=white)](https://siddhantkhare.com/)
 [![GitHub Sponsors](https://img.shields.io/badge/-Sponsor-EA4AAA?style=flat-square&logo=githubsponsors&logoColor=white)](https://github.com/sponsors/Siddhant-K-code)
+[![Buy Me a Coffee](https://img.shields.io/badge/-Buy%20me%20a%20coffee-FFDD00?style=flat-square&logo=buymeacoffee&logoColor=black)](https://buymeacoffee.com/siddhantkhare)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,51 +3,51 @@
 📍 **India** | 🛠️ **Engineer @ [Ona](https://ona.com/) (formerly Gitpod)** | 🔐 **[OpenFGA](https://openfga.dev) Core Maintainer** | 🎤 **International Speaker** | [**siddhantkhare.com**](https://siddhantkhare.com/)
 
 
-> Building infrastructure for AI agents — context efficiency, least-privilege security, production-grade tooling.
+> Building infrastructure for AI agents - context efficiency, least-privilege security, production-grade tooling.
 
 ## Current Projects
 
 ### Agent Infrastructure & Security
-- 🔐 **[agentic-authz](https://github.com/Siddhant-K-code/agentic-authz)** — OpenFGA + MCP authorization gateway for AI agents. Fine-grained access control at team, project, and tool levels.
-- 🧬 **[Distill](https://github.com/Siddhant-K-code/distill)** — Deterministic context deduplication for LLMs. Clean context in ~12ms, zero LLM calls.
-- 🔬 **[LLMTraceFX](https://github.com/Siddhant-K-code/LLMTraceFX)** — GPU-level LLM inference profiler with kernel timing and AI-powered bottleneck detection.
-- 🤖 **[Agentflow](https://github.com/Siddhant-K-code/agentflow)** — Kubernetes for AI agents — single platform for orchestration with capability-based security.
-- 🧪 **[ContextLab](https://github.com/Siddhant-K-code/contextlab)** — Open-source LLM context engineering toolkit: analyze, compress, visualize.
-- 💾 **[TokenVM](https://github.com/Siddhant-K-code/tokenvm)** — High-performance runtime treating LLM KV cache as virtual memory with page-based eviction.
+- 🔐 **[agentic-authz](https://github.com/Siddhant-K-code/agentic-authz)** - OpenFGA + MCP authorization gateway for AI agents. Fine-grained access control at team, project, and tool levels.
+- 🧬 **[Distill](https://github.com/Siddhant-K-code/distill)** - Deterministic context deduplication for LLMs. Clean context in ~12ms, zero LLM calls.
+- 🔬 **[LLMTraceFX](https://github.com/Siddhant-K-code/LLMTraceFX)** - GPU-level LLM inference profiler with kernel timing and AI-powered bottleneck detection.
+- 🤖 **[Agentflow](https://github.com/Siddhant-K-code/agentflow)** - Kubernetes for AI agents - single platform for orchestration with capability-based security.
+- 🧪 **[ContextLab](https://github.com/Siddhant-K-code/contextlab)** - Open-source LLM context engineering toolkit: analyze, compress, visualize.
+- 💾 **[TokenVM](https://github.com/Siddhant-K-code/tokenvm)** - High-performance runtime treating LLM KV cache as virtual memory with page-based eviction.
 
 ### Security & DevSecOps
-- 🛡️ **[Sentinel AI](https://github.com/Siddhant-K-code/sentinel-ai)** — Hermetic CLI for security scanning and dead-code detection with LLM-powered triage.
-- 🔒 **[actionsec](https://github.com/Siddhant-K-code/actionsec)** — Fast, local-first CLI for GitHub Actions security analysis.
-- 🔗 **[A2AS Implementation](https://github.com/Siddhant-K-code/a2as)** — Proof-of-concept of Agent-to-Agent Security framework.
+- 🛡️ **[Sentinel AI](https://github.com/Siddhant-K-code/sentinel-ai)** - Hermetic CLI for security scanning and dead-code detection with LLM-powered triage.
+- 🔒 **[actionsec](https://github.com/Siddhant-K-code/actionsec)** - Fast, local-first CLI for GitHub Actions security analysis.
+- 🔗 **[A2AS Implementation](https://github.com/Siddhant-K-code/a2as)** - Proof-of-concept of Agent-to-Agent Security framework.
 
 ### Developer Tools & MCP Servers
-- 🏗️ **[Cloud Architect AI](https://github.com/Siddhant-K-code/cloud-architect-ai)** — AI-powered cloud infrastructure design with architecture diagrams and Terraform code.
-- 📝 **[Apple Notes MCP Server](https://github.com/Siddhant-K-code/apple-notes-mcp)** — Interact with Apple Notes via natural language.
-- 📸 **[Smart Photo Journal MCP Server](https://github.com/Siddhant-K-code/smart-photo-journal-mcp)** — Search and analyze your photo library with AI.
-- 🐳 **[Devcontainer MCP Server](https://github.com/Siddhant-K-code/devcontainer-mcp)** — Manage DevContainers using AI prompts.
-- 🧹 **[Gitpod Environment Cleanup](https://github.com/Siddhant-K-code/cleanup-gitpod-environments)** — GitHub Action to find & delete stale Gitpod environments.
+- 🏗️ **[Cloud Architect AI](https://github.com/Siddhant-K-code/cloud-architect-ai)** - AI-powered cloud infrastructure design with architecture diagrams and Terraform code.
+- 📝 **[Apple Notes MCP Server](https://github.com/Siddhant-K-code/apple-notes-mcp)** - Interact with Apple Notes via natural language.
+- 📸 **[Smart Photo Journal MCP Server](https://github.com/Siddhant-K-code/smart-photo-journal-mcp)** - Search and analyze your photo library with AI.
+- 🐳 **[Devcontainer MCP Server](https://github.com/Siddhant-K-code/devcontainer-mcp)** - Manage DevContainers using AI prompts.
+- 🧹 **[Gitpod Environment Cleanup](https://github.com/Siddhant-K-code/cleanup-gitpod-environments)** - GitHub Action to find & delete stale Gitpod environments.
 
 ### Applications
-- 🎵 **[Song Vector Explorer](https://github.com/Siddhant-K-code/song-vector-explorer)** — Explore song lyrics as interactive 3D vector spaces.
-- 🗺️ **[SageMap](https://github.com/Siddhant-K-code/sagemap)** — Interactive tool to map and evolve personal beliefs.
-- 🏥 **[Radiology Copilot](https://github.com/Siddhant-K-code/radiology-copilot)** — Gemini-powered multimodal radiology assistant.
+- 🎵 **[Song Vector Explorer](https://github.com/Siddhant-K-code/song-vector-explorer)** - Explore song lyrics as interactive 3D vector spaces.
+- 🗺️ **[SageMap](https://github.com/Siddhant-K-code/sagemap)** - Interactive tool to map and evolve personal beliefs.
+- 🏥 **[Radiology Copilot](https://github.com/Siddhant-K-code/radiology-copilot)** - Gemini-powered multimodal radiology assistant.
 
 ### Maintainer Roles
-- 🔑 **[OpenFGA](https://github.com/openfga)** — Core Maintainer of Google Zanzibar-style fine-grained authorization system (CNCF Incubating). First independent maintainer.
-- 🔍 **[GitHub1s](https://github.com/conwnet/github1s)** — Maintainer of one-second code reading for GitHub repositories.
+- 🔑 **[OpenFGA](https://github.com/openfga)** - Core Maintainer of Google Zanzibar-style fine-grained authorization system (CNCF Incubating). First independent maintainer.
+- 🔍 **[GitHub1s](https://github.com/conwnet/github1s)** - Maintainer of one-second code reading for GitHub repositories.
 
 ### Legacy / Earlier Work
-- 🌍 **[Coronavirus Probability Checker](https://github.com/Siddhant-K-code/Coronavirus-Probability-Checker)** — COVID-19 probability checker based on symptom data.
-- 🩻 **[COVID-19 Rapid Tester](https://github.com/Siddhant-K-code/COVID-19-RAPID-TESTER)** — COVID-19 detector using chest X-ray analysis.
-- 🚀 **[404 Error Page — Astronaut](https://github.com/Siddhant-K-code/404-Error-Page---Astronaut)** — Animated 404 error page.
+- 🌍 **[Coronavirus Probability Checker](https://github.com/Siddhant-K-code/Coronavirus-Probability-Checker)** - COVID-19 probability checker based on symptom data.
+- 🩻 **[COVID-19 Rapid Tester](https://github.com/Siddhant-K-code/COVID-19-RAPID-TESTER)** - COVID-19 detector using chest X-ray analysis.
+- 🚀 **[404 Error Page - Astronaut](https://github.com/Siddhant-K-code/404-Error-Page---Astronaut)** - Animated 404 error page.
 
 ## What I'm Doing
 
-- **Engineering @ [Ona](https://ona.com/)** — Building infrastructure for AI agents (formerly Gitpod).
-- **Open Source** — Maintaining OpenFGA, GitHub1s, and shipping agent infrastructure tools.
-- **Writing** — 40+ technical articles on AI infrastructure, security, and context engineering on [Dev.to](https://dev.to/siddhantkcode) and [Medium](https://medium.com/@siddhantkhare).
-- **Speaking** — KubeCon India 2025: *Beyond Productivity: Scaling Cloud Dev Environments for Faster Feedback & Sustainable Engineering*. Available for conferences on AI agent security and authorization.
-- **Mentoring** — [Book a session on MentorCruise](https://mentorcruise.com/mentor/siddhantkhare/).
+- **Engineering @ [Ona](https://ona.com/)** - Building infrastructure for AI agents (formerly Gitpod).
+- **Open Source** - Maintaining OpenFGA, GitHub1s, and shipping agent infrastructure tools.
+- **Writing** - 40+ technical articles on AI infrastructure, security, and context engineering on [Dev.to](https://dev.to/siddhantkcode) and [Medium](https://medium.com/@siddhantkhare).
+- **Speaking** - KubeCon India 2025: *Beyond Productivity: Scaling Cloud Dev Environments for Faster Feedback & Sustainable Engineering*. Available for conferences on AI agent security and authorization.
+- **Mentoring** - [Book a session on MentorCruise](https://mentorcruise.com/mentor/siddhantkhare/).
 
 ## Latest Blog Posts
 
@@ -78,31 +78,32 @@
 
 ### Recognition
 
-- **[OpenFGA](https://openfga.dev) Core Maintainer** — First independent maintainer of a CNCF Incubating authorization project
-- **KubeCon India 2025 Speaker** — *Beyond Productivity: Scaling Cloud Dev Environments*
-- **Former GitHub Intern** — Contributed to GitHub's ecosystem
-- **Maintainer** — [OpenFGA](https://github.com/openfga), [GitHub1s](https://github.com/conwnet/github1s), [Greenstand](https://github.com/Greenstand), [Indian Open Source Foundation](https://github.com/IndianOpenSourceFoundation)
-- **40+ technical articles** — Published on [Dev.to](https://dev.to/siddhantkcode) and [Medium](https://medium.com/@siddhantkhare), multiple posts with 100+ reactions
+- **[OpenFGA](https://openfga.dev) Core Maintainer** - First independent maintainer of a CNCF Incubating authorization project
+- **KubeCon India 2025 Speaker** - *Beyond Productivity: Scaling Cloud Dev Environments*
+- **Former GitHub Intern**
+- **Maintainer** - [OpenFGA](https://github.com/openfga), [GitHub1s](https://github.com/conwnet/github1s), [Greenstand](https://github.com/Greenstand), [Indian Open Source Foundation](https://github.com/IndianOpenSourceFoundation)
+- **40+ technical articles** - Published on [Dev.to](https://dev.to/siddhantkcode) and [Medium](https://medium.com/@siddhantkhare), multiple posts with 100+ reactions
+- **Interviewed by [New York Times](https://www.nytimes.com/)** (Cade Metz) and **[NPR Here & Now](https://www.wbur.org/hereandnow)** on AI fatigue
+- **[Business Insider](https://www.businessinsider.com/ai-fatigue-burnout-software-engineer-essay-siddhant-khare-2026-2)** - Featured essay + [video segment](https://www.businessinsider.com/engineers-are-getting-ai-fatigue-and-you-could-be-next-2026-2)
+- **[Futurism](https://futurism.com/artificial-intelligence/ai-burnout-machine)** - *"AI Is a Burnout Machine"*
+- **[Techmeme](http://www.techmeme.com/260208/p15)** - Front page feature
+- **[Hacker News](https://news.ycombinator.com/item?id=46934404)** - #1, 446+ points, 310+ comments
+- **[The Chosun Ilbo](https://www.chosun.com/english/industry-en/2026/02/12/YJMVMG56ORHVJDHMKDQM2QMFCE/)** (South Korea's largest newspaper) - *"AI Fatigue Grows Despite Productivity Gains"*
+- **[NDTV Profit](https://www.ndtvprofit.com/technology/ai-backfire-stress-induced-burnout-could-be-tanking-your-work-quality-study-finds-10981522)** - Video segment on AI burnout
+- **[Computing UK](https://www.computing.co.uk/feature/2026/when-artificial-intelligence-makes-you-tired)** - Quoted extensively on AI fatigue
+- **[Kelsey Hightower](https://www.linkedin.com/in/kelseyhightower/)** - *"It's very real, which is why I'm glad people like you are raising awareness"*
+- Syndicated across **Yahoo**, **AOL**, **Business Insider Nordic/Africa/Italy**, **NewsBreak**, **daily.dev**, **Lobsters**, and others
+- Discussed on **Precursor Ventures** podcast by Charles Hudson and Mia Farnham
 
 ### Videos
 
-- **[Beyond Productivity: Scaling Cloud Dev Environments](https://www.youtube.com/@siddhantkhare1659)** — KubeCon India 2025
-- **[AI Agents Are a Security Nightmare (Here's the Fix)](https://www.youtube.com/@siddhantkhare1659)** — Agent authorization deep dive
-- **[Building a Medical AI Agent with Gemini 3 Pro](https://www.youtube.com/@siddhantkhare1659)** — End-to-end agent build
-
-### Media Coverage
-
-- **[Techmeme](http://www.techmeme.com/260208/p15)** — *"A software engineer explains 'AI fatigue', compounded by a FOMO treadmill of using AI labs' latest tools and 'thinking atrophy', alongside boosted productivity"*
-- **[Business Insider](https://www.businessinsider.com/ai-fatigue-burnout-software-engineer-essay-siddhant-khare-2026-2)** — *"'AI fatigue is real and nobody talks about it': A software engineer warns there's a mental cost to AI productivity gains"*
-- **[Hacker News](https://news.ycombinator.com/item?id=46934404)** — #1 on front page, 471+ points, 319+ comments
-- **[Computing UK](https://www.computing.co.uk/feature/2026/when-artificial-intelligence-makes-you-tired)** — *"AI fatigue: When artificial intelligence makes you tired"*
-- **[NewsBreak](https://www.newsbreak.com/morningoverview-358954986/4487947176601-ai-fatigue-is-real-engineer-warns-of-mental-toll-behind-ai-productivity-boom)** — *"'AI fatigue is real': engineer warns of mental toll behind AI productivity boom"*
-- **[Lobsters](https://lobste.rs/)** — Featured on front page
-- **[Kelsey Hightower](https://www.linkedin.com/in/kelseyhightower/)** (LinkedIn) — Shared and commented on the article
+- **[Beyond Productivity: Scaling Cloud Dev Environments](https://youtu.be/sFVQVBVOOV0)** - KubeCon India 2025
+- **[AI Agents Are a Security Nightmare (Here's the Fix)](https://youtube.com/watch?v=m1_l13bC2O8)** - Agent authorization deep dive
+- **[Building a Medical AI Agent with Gemini 3 Pro](https://youtube.com/watch?v=S6xULjtEZMM)** - End-to-end agent build
 
 ### Research Focus
 
 Building at the intersection of LLM efficiency and agent security:
-1. **Context Efficiency & Reliability** — Deterministic algorithms for context deduplication and optimization ([Distill](https://github.com/Siddhant-K-code/distill), [ContextLab](https://github.com/Siddhant-K-code/contextlab), [TokenVM](https://github.com/Siddhant-K-code/tokenvm))
-2. **Agent Authorization & Audit Trails** — Google Zanzibar-style authorization for agent-tool interactions ([agentic-authz](https://github.com/Siddhant-K-code/agentic-authz), [OpenFGA](https://github.com/openfga))
-3. **Adversarial Robustness & Observability** — Detecting and mitigating attacks on agent tool-use pipelines ([Sentinel AI](https://github.com/Siddhant-K-code/sentinel-ai), [LLMTraceFX](https://github.com/Siddhant-K-code/LLMTraceFX))
+1. **Context Efficiency & Reliability** - Deterministic algorithms for context deduplication and optimization ([Distill](https://github.com/Siddhant-K-code/distill), [ContextLab](https://github.com/Siddhant-K-code/contextlab), [TokenVM](https://github.com/Siddhant-K-code/tokenvm))
+2. **Agent Authorization & Audit Trails** - Google Zanzibar-style authorization for agent-tool interactions ([agentic-authz](https://github.com/Siddhant-K-code/agentic-authz), [OpenFGA](https://github.com/openfga))
+3. **Adversarial Robustness & Observability** - Detecting and mitigating attacks on agent tool-use pipelines ([Sentinel AI](https://github.com/Siddhant-K-code/sentinel-ai), [LLMTraceFX](https://github.com/Siddhant-K-code/LLMTraceFX))


### PR DESCRIPTION
Restructures the GitHub profile README following steipete's style — organized project catalog with descriptions, recognition section, testimonials, and research focus.

**What changed:**
- **Header** — Tech stack badges, tagline, location
- **Current Projects** — Categorized into Agent Infrastructure, Security, DevTools/MCP Servers, Applications
- **Maintainer Roles** — OpenFGA (CNCF Incubating), GitHub1s
- **Legacy Work** — Earlier projects preserved
- **What I'm Doing** — Current activities summary
- **Connect** — Badge-style social links
- **Recognition** — KubeCon speaker, GitHub intern, maintainer roles, writing stats
- **Videos** — YouTube content links
- **Testimonials** — Quotes from colleagues
- **Research Focus** — Three research areas with linked projects

Preserves the `<!--START_SECTION:feed-->` markers for the automated blog post workflow.